### PR TITLE
Stackname als key in der ETCD-Registry

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,6 +51,7 @@ Für eine App Pacman könnte das so aussehen:
           - APP_API_SERVICE=webcontent
           - APP_API_PORT=${APP_SIDECAR_WEBCONTENT_PORT}
           - APP_API_PATH=/
+          - STACK_NAME={{ .Stack.Name }}
 
 Hinweise:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
             - APP_API_PATH=
             - SSO_ACTIVATED=false
             - HOST_IP=192.168.1.107
+            - STACK_NAME=de-ondics-registration-test
 
     etcd:
        image: quay.io/coreos/etcd

--- a/register.sh
+++ b/register.sh
@@ -140,7 +140,7 @@ term_handler() {
 
   # Eintrag löschen
   echo "*** App deregistrieren"
-  curl --silent -L -X PUT "http://$ETCD_URI/v2/keys/apps/$APP_ID?recursive=true" \
+  curl --silent -L -X PUT "$APP_REGISTRY_URL?recursive=true" \
     -XDELETE >> /dev/null
 
   # alternativ: Status auf offline setzen

--- a/register.sh
+++ b/register.sh
@@ -73,7 +73,9 @@ while [ "$STATUS" != 'healthy' ]; do
 done
 echo "etcd is up"
 
-APP_REGISTRY_URL="http://$ETCD_URI/v2/keys/apps/$APP_ID"
+#überprüfen, ob stack-name gesetzt, sonst id verwenden
+${STACK_NAME:?"$APP_ID"}
+APP_REGISTRY_URL="http://$ETCD_URI/v2/keys/apps/$STACK_NAME"
 echo APP_REGISTRY_URL: $APP_REGISTRY_URL
 
 function etcd_add() {

--- a/register.sh
+++ b/register.sh
@@ -74,7 +74,9 @@ done
 echo "etcd is up"
 
 #überprüfen, ob stack-name gesetzt, sonst id verwenden
-${STACK_NAME:?"$APP_ID"}
+if [ -z ${STACK_NAME+x} ]; then 
+  STACK_NAME=$APP_ID
+fi
 APP_REGISTRY_URL="http://$ETCD_URI/v2/keys/apps/$STACK_NAME"
 echo APP_REGISTRY_URL: $APP_REGISTRY_URL
 


### PR DESCRIPTION
Da die App-Id nciht eindeutig ist, soll der Key in der ETCD-Registry der Stackname sein.